### PR TITLE
Don't redefine existing self

### DIFF
--- a/polyfills/globalself.js
+++ b/polyfills/globalself.js
@@ -5,4 +5,4 @@
  * and web-workers alike.
  */
 
-global.self = global;
+if (typeof global.self === "undefined") global.self = global;


### PR DESCRIPTION
When the react native debugger is active, the code runs in a web worker that has self defined as read only.